### PR TITLE
Fix: Parameter list only works if item is last

### DIFF
--- a/Tests/EnumIdentableTests/EnumIdentableTests.swift
+++ b/Tests/EnumIdentableTests/EnumIdentableTests.swift
@@ -26,7 +26,7 @@ final class EnumIdentableTests: XCTestCase {
             """
             ,
             expandedSource:
-            """
+            #"""
             enum TestEnum {
                 case one
                 case two
@@ -61,7 +61,7 @@ final class EnumIdentableTests: XCTestCase {
                     lhs.id == rhs.id
                 }
             }
-            """
+            """#
             ,
             macros: testMacros
         )
@@ -81,7 +81,7 @@ final class EnumIdentableTests: XCTestCase {
             """
             ,
             expandedSource:
-            """
+            #"""
             enum TestEnum {
                 case one(String)
 
@@ -108,7 +108,7 @@ final class EnumIdentableTests: XCTestCase {
                     lhs.id == rhs.id
                 }
             }
-            """
+            """#
             ,
             macros: testMacros
         )
@@ -128,7 +128,7 @@ final class EnumIdentableTests: XCTestCase {
             """
             ,
             expandedSource:
-            """
+            #"""
             enum TestEnum {
                 case one, two, three
 
@@ -161,7 +161,7 @@ final class EnumIdentableTests: XCTestCase {
                     lhs.id == rhs.id
                 }
             }
-            """
+            """#
             ,
             macros: testMacros
         )
@@ -184,7 +184,7 @@ final class EnumIdentableTests: XCTestCase {
             """
             ,
             expandedSource:
-            """
+            #"""
             enum TestEnum {
                 case one(id: String)
                 case two(model: String)
@@ -199,13 +199,13 @@ final class EnumIdentableTests: XCTestCase {
                     var rawValue: String {
                         switch self {
                         case let .one(id):
-                            "one-\\(id)"
+                            "one-\(id)"
                         case .two:
                             "two"
                         case .three:
                             "three"
                         case let .four(modelId):
-                            "four-\\(modelId)"
+                            "four-\(modelId)"
                         }
                     }
                 }
@@ -235,7 +235,7 @@ final class EnumIdentableTests: XCTestCase {
                     lhs.id == rhs.id
                 }
             }
-            """
+            """#
             ,
             macros: testMacros
         )
@@ -255,7 +255,7 @@ final class EnumIdentableTests: XCTestCase {
             """
             ,
             expandedSource:
-            """
+            #"""
             enum Destination: Hashable, Identifiable {
                 case destination(id: Int, a: String)
 
@@ -264,7 +264,7 @@ final class EnumIdentableTests: XCTestCase {
                     var rawValue: String {
                         switch self {
                         case let .destination(id):
-                            "destination-\\(id)"
+                            "destination-\(id)"
                         }
                     }
                 }
@@ -288,7 +288,7 @@ final class EnumIdentableTests: XCTestCase {
                     lhs.id == rhs.id
                 }
             }
-            """
+            """#
             ,
             macros: testMacros
         )


### PR DESCRIPTION
The issue was caused by inappropriate work with syntax tokens.

```swift
let parameterName = $0.firstToken(viewMode: .fixedUp)
let parameterType = $0.lastToken(viewMode: .fixedUp)
```

Code above didn't take into account, that in parameter list, such as `hello: Int, miki: String`, the first item of the list is `hello: Int,` and the second is `miki: String`. Thus the last token of the first item is "," not "Int".

I suggest using type cast `as(_:)` wherever possible.