### PR TITLE
Add @CacheProjection macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
             name: "FuturedMacros",
             targets: [
                 "EnumIdentable",
-                "ProxyMembers"
+                "ProxyMembers",
+                "CacheProjection"
             ]
         )
     ],
@@ -34,10 +35,18 @@ let package = Package(
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
             ]
         ),
+        .macro(
+            name: "CacheProjectionMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
 
         // Library that exposes a macro as part of its API, which is used in client programs.
         .target(name: "EnumIdentable", dependencies: ["EnumIdentableMacros"]),
         .target(name: "ProxyMembers", dependencies: ["ProxyMembersMacros"]),
+        .target(name: "CacheProjection", dependencies: ["CacheProjectionMacros", "ProxyMembers"]),
 
         // A test target used to develop the macro implementation.
         .testTarget(
@@ -51,6 +60,13 @@ let package = Package(
             name: "ProxyMembersTests",
             dependencies: [
                 "ProxyMembersMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+            ]
+        ),
+        .testTarget(
+            name: "CacheProjectionTests",
+            dependencies: [
+                "CacheProjectionMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
             ]
         )

--- a/Sources/CacheProjection/CacheProjection.swift
+++ b/Sources/CacheProjection/CacheProjection.swift
@@ -1,0 +1,53 @@
+@_exported import ProxyMembers
+
+/// Generates the boilerplate of a `CacheProjection`-conforming struct: the `state`
+/// property, the `@ProxyMembers var data` storage, the `empty(state:)` factory, and
+/// the `CacheProjection` conformance extension.
+///
+/// Apply to a `struct` that already has the `@dynamicMemberLookup` attribute. The
+/// `state:` and `data:` arguments name the projection's State and Data types as
+/// metatypes — both are required, no defaults.
+///
+/// ```swift
+/// @CacheProjection(state: ComponentState.self, data: HomeData.self)
+/// @dynamicMemberLookup
+/// nonisolated struct HomeCacheProjection {
+///     static func data(from cache: DataCacheModel) -> Self? { ... }
+/// }
+/// ```
+///
+/// Expands to (additions marked with comments):
+///
+/// ```swift
+/// @dynamicMemberLookup
+/// nonisolated struct HomeCacheProjection {
+///     static func data(from cache: DataCacheModel) -> Self? { ... }
+///
+///     var state: ComponentState                                // ← generated
+///     @ProxyMembers var data: HomeData                         // ← generated
+///
+///     static func empty(state: ComponentState) -> Self {       // ← generated
+///         Self(state: state, data: .mock)
+///     }
+/// }
+///
+/// extension HomeCacheProjection: CacheProjection {}            // ← generated
+/// ```
+///
+/// The emitted `@ProxyMembers var data: ...` is itself a macro invocation; Swift's
+/// macro expansion is iterative, so on the next pass `@ProxyMembers` synthesizes
+/// the `subscript(dynamicMember:)` accessor on the struct.
+///
+/// - Important: The Data type must conform to `Mockable` (`static var mock: Self`).
+///   This is not enforceable as a generic constraint at the macro declaration
+///   (`Mockable` is project-local), so a non-conforming Data type surfaces as a
+///   `Type '...' has no member 'mock'` compile error at the use site.
+///
+/// - Important: Apply `@dynamicMemberLookup` to the struct yourself — macros cannot
+///   annotate the host declaration.
+@attached(member, names: named(state), named(data), named(empty(state:)))
+@attached(extension, names: arbitrary)
+public macro CacheProjection<State, Data>(
+    state: State.Type,
+    data: Data.Type
+) = #externalMacro(module: "CacheProjectionMacros", type: "CacheProjectionMacro")

--- a/Sources/CacheProjectionMacros/CacheProjectionMacro.swift
+++ b/Sources/CacheProjectionMacros/CacheProjectionMacro.swift
@@ -1,0 +1,56 @@
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+public enum CacheProjectionMacro {
+    struct ParsedArguments {
+        let stateTypeName: String
+        let dataTypeName: String
+    }
+
+    /// Reads `state:` and `data:` arguments from the macro attribute, expecting
+    /// each as a `T.self` metatype expression. Returns `nil` if the shape is
+    /// wrong; the diagnostic is emitted by the caller so the caller can choose
+    /// the right reporting node.
+    static func parseArguments(from node: AttributeSyntax) -> ParsedArguments? {
+        guard let arguments = node.arguments?.as(LabeledExprListSyntax.self) else {
+            return nil
+        }
+
+        var stateTypeName: String?
+        var dataTypeName: String?
+
+        for argument in arguments {
+            guard let label = argument.label?.text else { continue }
+            guard let typeName = baseTypeName(of: argument.expression) else { continue }
+            switch label {
+            case "state":
+                stateTypeName = typeName
+            case "data":
+                dataTypeName = typeName
+            default:
+                continue
+            }
+        }
+
+        guard let stateTypeName, let dataTypeName else {
+            return nil
+        }
+
+        return ParsedArguments(stateTypeName: stateTypeName, dataTypeName: dataTypeName)
+    }
+
+    /// Extracts `ComponentState` from a `ComponentState.self` expression, or
+    /// `nil` if the expression is anything else.
+    private static func baseTypeName(of expression: ExprSyntax) -> String? {
+        guard let memberAccess = expression.as(MemberAccessExprSyntax.self) else {
+            return nil
+        }
+        guard memberAccess.declName.baseName.text == "self" else {
+            return nil
+        }
+        guard let base = memberAccess.base else {
+            return nil
+        }
+        return base.trimmedDescription
+    }
+}

--- a/Sources/CacheProjectionMacros/Diagnostics.swift
+++ b/Sources/CacheProjectionMacros/Diagnostics.swift
@@ -1,0 +1,23 @@
+import SwiftDiagnostics
+
+extension CacheProjectionMacro {
+    public enum Diagnostics: String, DiagnosticMessage {
+        case mustBeStruct
+        case argumentNotMetatype
+
+        public var message: String {
+            switch self {
+            case .mustBeStruct:
+                "`@CacheProjection` can only be applied to a `struct`"
+            case .argumentNotMetatype:
+                "`@CacheProjection` requires metatype arguments (e.g. `state: ComponentState.self`, `data: HomeData.self`)"
+            }
+        }
+
+        public var diagnosticID: MessageID {
+            MessageID(domain: "CacheProjectionMacro", id: rawValue)
+        }
+
+        public var severity: DiagnosticSeverity { .error }
+    }
+}

--- a/Sources/CacheProjectionMacros/ExtensionExpansion.swift
+++ b/Sources/CacheProjectionMacros/ExtensionExpansion.swift
@@ -1,0 +1,24 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension CacheProjectionMacro: ExtensionMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        attachedTo declaration: some DeclGroupSyntax,
+        providingExtensionsOf type: some TypeSyntaxProtocol,
+        conformingTo protocols: [TypeSyntax],
+        in context: some MacroExpansionContext
+    ) throws -> [ExtensionDeclSyntax] {
+        guard declaration.is(StructDeclSyntax.self) else {
+            // The MemberMacro pass already emitted the diagnostic; just bail.
+            return []
+        }
+
+        let conformanceExtension = try ExtensionDeclSyntax(
+            "extension \(type): CacheProjection {}"
+        )
+
+        return [conformanceExtension]
+    }
+}

--- a/Sources/CacheProjectionMacros/MemberExpansion.swift
+++ b/Sources/CacheProjectionMacros/MemberExpansion.swift
@@ -1,0 +1,35 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension CacheProjectionMacro: MemberMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingMembersOf declaration: some DeclGroupSyntax,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard declaration.is(StructDeclSyntax.self) else {
+            context.diagnose(Diagnostic(node: node._syntaxNode, message: Diagnostics.mustBeStruct))
+            return []
+        }
+
+        guard let arguments = parseArguments(from: node) else {
+            context.diagnose(Diagnostic(node: node._syntaxNode, message: Diagnostics.argumentNotMetatype))
+            return []
+        }
+
+        let stateType = arguments.stateTypeName
+        let dataType = arguments.dataTypeName
+
+        let stateProperty: DeclSyntax = "var state: \(raw: stateType)"
+        let dataProperty: DeclSyntax = "@ProxyMembers var data: \(raw: dataType)"
+        let emptyFactory: DeclSyntax =
+            """
+            static func empty(state: \(raw: stateType)) -> Self {
+                Self(state: state, data: .mock)
+            }
+            """
+
+        return [stateProperty, dataProperty, emptyFactory]
+    }
+}

--- a/Sources/CacheProjectionMacros/Plugin.swift
+++ b/Sources/CacheProjectionMacros/Plugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct CacheProjectionPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        CacheProjectionMacro.self
+    ]
+}

--- a/Tests/CacheProjectionTests/CacheProjectionTests.swift
+++ b/Tests/CacheProjectionTests/CacheProjectionTests.swift
@@ -1,0 +1,203 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(CacheProjectionMacros)
+import CacheProjectionMacros
+
+let testMacros: [String: Macro.Type] = [
+    "CacheProjection": CacheProjectionMacro.self
+]
+#endif
+
+final class CacheProjectionTests: XCTestCase {
+    func testComponentStateExpansion() throws {
+        #if canImport(CacheProjectionMacros)
+        assertMacroExpansion(
+            """
+            @CacheProjection(state: ComponentState.self, data: HomeData.self)
+            @dynamicMemberLookup
+            nonisolated struct HomeCacheProjection {
+                static func data(from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+            }
+            """,
+            expandedSource:
+            """
+            @dynamicMemberLookup
+            nonisolated struct HomeCacheProjection {
+                static func data(from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+
+                var state: ComponentState
+
+                @ProxyMembers var data: HomeData
+
+                static func empty(state: ComponentState) -> Self {
+                    Self(state: state, data: .mock)
+                }
+            }
+
+            extension HomeCacheProjection: CacheProjection {
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testProjectionStateExpansion() throws {
+        #if canImport(CacheProjectionMacros)
+        assertMacroExpansion(
+            """
+            @CacheProjection(state: ProjectionState.self, data: CurrentBuildingData.self)
+            @dynamicMemberLookup
+            struct CurrentBuildingCacheProjection {
+                static func data(from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+            }
+            """,
+            expandedSource:
+            """
+            @dynamicMemberLookup
+            struct CurrentBuildingCacheProjection {
+                static func data(from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+
+                var state: ProjectionState
+
+                @ProxyMembers var data: CurrentBuildingData
+
+                static func empty(state: ProjectionState) -> Self {
+                    Self(state: state, data: .mock)
+                }
+            }
+
+            extension CurrentBuildingCacheProjection: CacheProjection {
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testKeyedProjection() throws {
+        #if canImport(CacheProjectionMacros)
+        assertMacroExpansion(
+            """
+            @CacheProjection(state: ComponentState.self, data: PerformerDetailData.self)
+            @dynamicMemberLookup
+            nonisolated struct PerformerDetailCacheProjection {
+                typealias ID = Int
+
+                static func data(from _: DataCacheModel) -> Self? {
+                    nil
+                }
+
+                static func data(for id: Int, from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+            }
+            """,
+            expandedSource:
+            """
+            @dynamicMemberLookup
+            nonisolated struct PerformerDetailCacheProjection {
+                typealias ID = Int
+
+                static func data(from _: DataCacheModel) -> Self? {
+                    nil
+                }
+
+                static func data(for id: Int, from cache: DataCacheModel) -> Self? {
+                    nil
+                }
+
+                var state: ComponentState
+
+                @ProxyMembers var data: PerformerDetailData
+
+                static func empty(state: ComponentState) -> Self {
+                    Self(state: state, data: .mock)
+                }
+            }
+
+            extension PerformerDetailCacheProjection: CacheProjection {
+            }
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testDiagnosticMustBeStruct() throws {
+        #if canImport(CacheProjectionMacros)
+        assertMacroExpansion(
+            """
+            @CacheProjection(state: ComponentState.self, data: BadData.self)
+            enum NotAStruct {
+                case foo
+            }
+            """,
+            expandedSource:
+            """
+            enum NotAStruct {
+                case foo
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "`@CacheProjection` can only be applied to a `struct`",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testDiagnosticArgumentNotMetatype() throws {
+        #if canImport(CacheProjectionMacros)
+        assertMacroExpansion(
+            """
+            @CacheProjection(state: "string", data: HomeData.self)
+            @dynamicMemberLookup
+            struct BadProjection {
+            }
+            """,
+            expandedSource:
+            """
+            @dynamicMemberLookup
+            struct BadProjection {
+            }
+
+            extension BadProjection: CacheProjection {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "`@CacheProjection` requires metatype arguments (e.g. `state: ComponentState.self`, `data: HomeData.self`)",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `@CacheProjection<State, Data>(state:, data:)` macro that generates `var state: State`, `@ProxyMembers var data: Data`, `static func empty(state:)`, and `extension X: CacheProjection {}` on the host struct.
- Both args are required Swift generic-parameter metatypes — explicit at every call site, no defaults. Covers smsticket-ios + jt-assets-ios (`state: ComponentState.self`) and armage-ios (`state: ProjectionState.self`).
- The emitted `@ProxyMembers var data: ...` re-expands on the next compiler pass; the `CacheProjection` library re-exports `ProxyMembers` so callers need only `import CacheProjection`.

## Diagnostics

- `mustBeStruct` — applied to non-struct decl
- `argumentNotMetatype` — `state:` / `data:` argument not a `.self` metatype expression

Non-`Mockable` Data types surface as a clean `Type '...' has no member 'mock'` error at the use site — no need for the macro to reproduce that check.

## Tests

5 cases via `assertMacroExpansion`: `ComponentState` expansion, `ProjectionState` expansion, keyed projection (`typealias ID = Int`), and both diagnostics. Pre-existing `EnumIdentableTests` failures on `main` are unrelated to this change (see `ExtensionExpansion.swift:63` comment).

## Out of scope

- `@AutoMock` ships in a separate PR.
- Adoption in `smsticket-ios` follows in `smsticket-ios#feature/cache-projection-adoption` once this is tagged `0.3.0`.