### PR TITLE
Add @AutoMock macro

### DIFF
--- a/Package.swift
+++ b/Package.swift
@@ -11,7 +11,8 @@ let package = Package(
             name: "FuturedMacros",
             targets: [
                 "EnumIdentable",
-                "ProxyMembers"
+                "ProxyMembers",
+                "AutoMock"
             ]
         )
     ],
@@ -34,10 +35,18 @@ let package = Package(
                 .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
             ]
         ),
+        .macro(
+            name: "AutoMockMacros",
+            dependencies: [
+                .product(name: "SwiftSyntaxMacros", package: "swift-syntax"),
+                .product(name: "SwiftCompilerPlugin", package: "swift-syntax")
+            ]
+        ),
 
         // Library that exposes a macro as part of its API, which is used in client programs.
         .target(name: "EnumIdentable", dependencies: ["EnumIdentableMacros"]),
         .target(name: "ProxyMembers", dependencies: ["ProxyMembersMacros"]),
+        .target(name: "AutoMock", dependencies: ["AutoMockMacros"]),
 
         // A test target used to develop the macro implementation.
         .testTarget(
@@ -51,6 +60,13 @@ let package = Package(
             name: "ProxyMembersTests",
             dependencies: [
                 "ProxyMembersMacros",
+                .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
+            ]
+        ),
+        .testTarget(
+            name: "AutoMockTests",
+            dependencies: [
+                "AutoMockMacros",
                 .product(name: "SwiftSyntaxMacrosTestSupport", package: "swift-syntax")
             ]
         )

--- a/Sources/AutoMock/AutoMock.swift
+++ b/Sources/AutoMock/AutoMock.swift
@@ -1,0 +1,57 @@
+/// Generates a `#if DEBUG`-wrapped `@Observable final class <Name>Mock` that
+/// conforms to the attached protocol with empty stubs and primitive-default
+/// property values.
+///
+/// Apply to a `*ComponentModelProtocol` declaration. The macro:
+/// - Strips the trailing `Protocol` from the protocol's name to compute the
+///   mock class name (`HomeComponentModelProtocol` → `HomeComponentModelMock`).
+/// - Emits `var onEvent: (Event) -> Void = { _ in }` (required by
+///   `ComponentModel`).
+/// - Emits a stored `var` for each property requirement, with a primitive
+///   default when the type is trivially defaultable (`String`, `Int`, `Bool`,
+///   `Optional`, `Array`, `Dictionary`, `Set`, numeric).
+/// - Properties with non-defaultable types become required `init` parameters.
+/// - Methods get empty bodies (or hardcoded primitive returns where the
+///   return type allows; `fatalError` for custom return types).
+///
+/// ```swift
+/// @AutoMock
+/// protocol HomeComponentModelProtocol: ComponentModel {
+///     var projection: HomeCacheProjection { get }
+///     var isPushPromptVisible: Bool { get }
+///     func onAppear() async
+///     func onEventTapped(_ event: EventListItem)
+/// }
+/// ```
+///
+/// Expands to (paired with the original protocol):
+///
+/// ```swift
+/// #if DEBUG
+/// @Observable
+/// final class HomeComponentModelMock: HomeComponentModelProtocol {
+///     var onEvent: (Event) -> Void = { _ in }
+///     var projection: HomeCacheProjection
+///     var isPushPromptVisible: Bool = false
+///
+///     init(projection: HomeCacheProjection) {
+///         self.projection = projection
+///     }
+///
+///     func onAppear() async {}
+///     func onEventTapped(_: EventListItem) {}
+/// }
+/// #endif
+/// ```
+///
+/// Customize the generated mock through three mechanisms — none requires
+/// macro arguments:
+/// 1. Post-init property mutation at the call site (`mock.x = "Jan"`).
+/// 2. Convenience inits in a `#if DEBUG` extension.
+/// 3. Skip the macro for protocols whose mock needs meaningful in-method
+///    behavior (e.g. `toggleFavorite()` mutating state).
+///
+/// - Important: The attached protocol's name must end in `Protocol`. The
+///   macro emits a `protocolNameMustEndInProtocol` diagnostic otherwise.
+@attached(peer, names: arbitrary)
+public macro AutoMock() = #externalMacro(module: "AutoMockMacros", type: "AutoMockMacro")

--- a/Sources/AutoMockMacros/AutoMockMacro.swift
+++ b/Sources/AutoMockMacros/AutoMockMacro.swift
@@ -1,0 +1,48 @@
+import SwiftSyntax
+
+public enum AutoMockMacro {
+    /// One protocol property requirement parsed into the pieces the expansion needs.
+    struct PropertyRequirement {
+        let name: String
+        let type: TypeSyntax
+        /// Default expression for this type, or `nil` if the type isn't trivially
+        /// defaultable — in which case the property becomes an `init` parameter.
+        let defaultExpression: String?
+
+        var isInitParameter: Bool { defaultExpression == nil }
+    }
+
+    /// One protocol method requirement parsed into the pieces the expansion needs.
+    struct MethodRequirement {
+        let signature: FunctionDeclSyntax
+        /// Body string to emit (e.g. `{}`, `{ false }`, `{ fatalError(...) }`).
+        let body: String
+    }
+
+    static func mockClassName(for protocolName: String) -> String? {
+        guard protocolName.hasSuffix("Protocol") else {
+            return nil
+        }
+        let base = String(protocolName.dropLast("Protocol".count))
+        return "\(base)Mock"
+    }
+
+    static func parseProperty(from variable: VariableDeclSyntax) -> PropertyRequirement? {
+        guard let binding = variable.bindings.first else { return nil }
+        guard let identifier = binding.pattern.as(IdentifierPatternSyntax.self)?.identifier.text else {
+            return nil
+        }
+        guard let type = binding.typeAnnotation?.type else { return nil }
+        return PropertyRequirement(
+            name: identifier,
+            type: type,
+            defaultExpression: TypeDefaults.defaultExpression(for: type)
+        )
+    }
+
+    static func parseMethod(from function: FunctionDeclSyntax) -> MethodRequirement {
+        let returnType = function.signature.returnClause?.type
+        let body = TypeDefaults.functionBody(returnType: returnType, mockClassReference: "Self.self")
+        return MethodRequirement(signature: function, body: body)
+    }
+}

--- a/Sources/AutoMockMacros/Diagnostics.swift
+++ b/Sources/AutoMockMacros/Diagnostics.swift
@@ -1,0 +1,26 @@
+import SwiftDiagnostics
+
+extension AutoMockMacro {
+    public enum Diagnostics: String, DiagnosticMessage {
+        case mustBeProtocol
+        case protocolNameMustEndInProtocol
+        case unsupportedRequirement
+
+        public var message: String {
+            switch self {
+            case .mustBeProtocol:
+                "`@AutoMock` can only be applied to a `protocol`"
+            case .protocolNameMustEndInProtocol:
+                "`@AutoMock` requires the protocol name to end in `Protocol` (e.g. `HomeComponentModelProtocol`) so the mock class name can be derived (`HomeComponentModelMock`)"
+            case .unsupportedRequirement:
+                "`@AutoMock` does not yet support this requirement kind; declare the mock class manually for this protocol"
+            }
+        }
+
+        public var diagnosticID: MessageID {
+            MessageID(domain: "AutoMockMacro", id: rawValue)
+        }
+
+        public var severity: DiagnosticSeverity { .error }
+    }
+}

--- a/Sources/AutoMockMacros/PeerExpansion.swift
+++ b/Sources/AutoMockMacros/PeerExpansion.swift
@@ -1,0 +1,150 @@
+import SwiftDiagnostics
+import SwiftSyntax
+import SwiftSyntaxMacros
+
+extension AutoMockMacro: PeerMacro {
+    public static func expansion(
+        of node: AttributeSyntax,
+        providingPeersOf declaration: some DeclSyntaxProtocol,
+        in context: some MacroExpansionContext
+    ) throws -> [DeclSyntax] {
+        guard let protocolDecl = declaration.as(ProtocolDeclSyntax.self) else {
+            context.diagnose(Diagnostic(node: node._syntaxNode, message: Diagnostics.mustBeProtocol))
+            return []
+        }
+
+        let protocolName = protocolDecl.name.text
+
+        guard let mockName = mockClassName(for: protocolName) else {
+            context.diagnose(Diagnostic(node: protocolDecl.name, message: Diagnostics.protocolNameMustEndInProtocol))
+            return []
+        }
+
+        var properties: [PropertyRequirement] = []
+        var methods: [MethodRequirement] = []
+
+        for member in protocolDecl.memberBlock.members {
+            if let variable = member.decl.as(VariableDeclSyntax.self) {
+                guard let property = parseProperty(from: variable) else { continue }
+                properties.append(property)
+                continue
+            }
+            if let function = member.decl.as(FunctionDeclSyntax.self) {
+                methods.append(parseMethod(from: function))
+                continue
+            }
+            if member.decl.is(SubscriptDeclSyntax.self)
+                || member.decl.is(AssociatedTypeDeclSyntax.self)
+                || member.decl.is(InitializerDeclSyntax.self) {
+                context.diagnose(Diagnostic(node: member._syntaxNode, message: Diagnostics.unsupportedRequirement))
+                return []
+            }
+        }
+
+        let initParameters = properties.filter(\.isInitParameter)
+
+        let propertyDecls: String = properties
+            .map { property in
+                if let defaultExpr = property.defaultExpression {
+                    "    var \(property.name): \(property.type.trimmedDescription) = \(defaultExpr)"
+                } else {
+                    "    var \(property.name): \(property.type.trimmedDescription)"
+                }
+            }
+            .joined(separator: "\n")
+
+        let initSection: String = if initParameters.isEmpty {
+            ""
+        } else {
+            renderInit(parameters: initParameters)
+        }
+
+        let methodDecls: String = methods
+            .map { renderMethod($0) }
+            .joined(separator: "\n\n")
+
+        // Determine class-name reference for fatalError messages. Using "Self.self" is fine — at
+        // runtime it resolves to the mock class.
+
+        var classBody: [String] = []
+        classBody.append("    var onEvent: (Event) -> Void = { _ in }")
+        if !propertyDecls.isEmpty {
+            classBody.append(propertyDecls)
+        }
+        if !initSection.isEmpty {
+            classBody.append(initSection)
+        }
+        if !methodDecls.isEmpty {
+            classBody.append(methodDecls)
+        }
+
+        let mockClass: String =
+            """
+            #if DEBUG
+            @Observable
+            final class \(mockName): \(protocolName) {
+            \(classBody.joined(separator: "\n\n"))
+            }
+            #endif
+            """
+
+        return [DeclSyntax(stringLiteral: mockClass)]
+    }
+
+    private static func renderInit(parameters: [PropertyRequirement]) -> String {
+        let paramLines = parameters
+            .map { "        \($0.name): \($0.type.trimmedDescription)" }
+            .joined(separator: ",\n")
+        let assignments = parameters
+            .map { "        self.\($0.name) = \($0.name)" }
+            .joined(separator: "\n")
+        return """
+            init(
+        \(paramLines)
+            ) {
+        \(assignments)
+            }
+        """
+    }
+
+    private static func renderMethod(_ method: MethodRequirement) -> String {
+        let signature = method.signature
+        let name = signature.name.text
+        let parameters = renderMethodParameters(signature.signature.parameterClause.parameters)
+        let effects = renderEffectSpecifiers(signature.signature.effectSpecifiers)
+        let returnClause = signature.signature.returnClause.map { " -> \($0.type.trimmedDescription)" } ?? ""
+        let header = "    func \(name)(\(parameters))\(effects)\(returnClause)"
+        return "\(header) \(method.body)"
+    }
+
+    private static func renderMethodParameters(_ parameters: FunctionParameterListSyntax) -> String {
+        // Preserve the external label, replace the internal name with `_` to suppress
+        // unused-parameter warnings in the empty stub bodies.
+        parameters
+            .map { parameter in
+                let externalLabel = parameter.firstName.text
+                let type = parameter.type.trimmedDescription
+                if externalLabel == "_" {
+                    return "_: \(type)"
+                }
+                return "\(externalLabel) _: \(type)"
+            }
+            .joined(separator: ", ")
+    }
+
+    private static func renderEffectSpecifiers(_ effects: FunctionEffectSpecifiersSyntax?) -> String {
+        guard let effects else { return "" }
+        var parts: [String] = []
+        if effects.asyncSpecifier != nil {
+            parts.append("async")
+        }
+        if let throwsClause = effects.throwsClause {
+            if let thrownType = throwsClause.type {
+                parts.append("throws(\(thrownType.trimmedDescription))")
+            } else {
+                parts.append("throws")
+            }
+        }
+        return parts.isEmpty ? "" : " \(parts.joined(separator: " "))"
+    }
+}

--- a/Sources/AutoMockMacros/Plugin.swift
+++ b/Sources/AutoMockMacros/Plugin.swift
@@ -1,0 +1,9 @@
+import SwiftCompilerPlugin
+import SwiftSyntaxMacros
+
+@main
+struct AutoMockPlugin: CompilerPlugin {
+    let providingMacros: [Macro.Type] = [
+        AutoMockMacro.self
+    ]
+}

--- a/Sources/AutoMockMacros/TypeDefaults.swift
+++ b/Sources/AutoMockMacros/TypeDefaults.swift
@@ -1,0 +1,100 @@
+import SwiftSyntax
+
+/// Maps an as-written `TypeSyntax` to a default expression for stored
+/// properties and to a return-value expression for method bodies.
+///
+/// Detection works on the *spelling* of the type (the user-written tokens),
+/// not on the resolved Swift type — the macro has no access to the type
+/// checker. `[String]` and `Array<String>` resolve to the same Swift type but
+/// only `[String]` is what we see at this layer; both are handled.
+enum TypeDefaults {
+    /// Trivially defaultable primitive type names.
+    private static let numericTypes: Set<String> = [
+        "Int", "Int8", "Int16", "Int32", "Int64",
+        "UInt", "UInt8", "UInt16", "UInt32", "UInt64",
+        "Float", "Float32", "Float64", "Double", "CGFloat"
+    ]
+
+    /// Returns the default initializer expression for the given type, or
+    /// `nil` if the type isn't trivially defaultable. Properties of
+    /// non-defaultable type become required `init` parameters.
+    static func defaultExpression(for type: TypeSyntax) -> String? {
+        // Optional<T> — any of `T?`, `Optional<T>`, `T!`.
+        if type.is(OptionalTypeSyntax.self) || type.is(ImplicitlyUnwrappedOptionalTypeSyntax.self) {
+            return "nil"
+        }
+        if let generic = type.as(IdentifierTypeSyntax.self),
+           generic.name.text == "Optional",
+           generic.genericArgumentClause != nil {
+            return "nil"
+        }
+
+        // Array<T> — either `[T]` or `Array<T>`.
+        if type.is(ArrayTypeSyntax.self) {
+            return "[]"
+        }
+        if let generic = type.as(IdentifierTypeSyntax.self),
+           generic.name.text == "Array",
+           generic.genericArgumentClause != nil {
+            return "[]"
+        }
+
+        // Set<T>.
+        if let generic = type.as(IdentifierTypeSyntax.self),
+           generic.name.text == "Set",
+           generic.genericArgumentClause != nil {
+            return "[]"
+        }
+
+        // Dictionary<K, V> — either `[K: V]` or `Dictionary<K, V>`.
+        if type.is(DictionaryTypeSyntax.self) {
+            return "[:]"
+        }
+        if let generic = type.as(IdentifierTypeSyntax.self),
+           generic.name.text == "Dictionary",
+           generic.genericArgumentClause != nil {
+            return "[:]"
+        }
+
+        // Primitive identifier types.
+        if let identifier = type.as(IdentifierTypeSyntax.self),
+           identifier.genericArgumentClause == nil {
+            let name = identifier.name.text
+            switch name {
+            case "String": return "\"\""
+            case "Bool": return "false"
+            default:
+                if numericTypes.contains(name) {
+                    return "0"
+                }
+                return nil
+            }
+        }
+
+        return nil
+    }
+
+    /// Returns the body literal (including the surrounding braces) for a
+    /// method whose return clause is `returnType` (or `nil` for `Void`).
+    ///
+    /// - `Void` / nil return → `{}`
+    /// - Primitive returns → hardcoded primitive value
+    /// - Optional / Array / Dictionary returns → `{ nil }` / `{ [] }` / `{ [:] }`
+    /// - Custom return → `{ fatalError(...) }` that points at the calling site
+    static func functionBody(returnType: TypeSyntax?, mockClassReference: String) -> String {
+        guard let returnType else {
+            return "{}"
+        }
+
+        if let value = defaultExpression(for: returnType) {
+            return "{ \(value) }"
+        }
+
+        // Unknown return type — caller must override the mock to use this method.
+        return """
+        {
+            fatalError("\\(#function) not stubbed in \\(\(mockClassReference)) — override the mock to use this method")
+        }
+        """
+    }
+}

--- a/Tests/AutoMockTests/AutoMockTests.swift
+++ b/Tests/AutoMockTests/AutoMockTests.swift
@@ -1,0 +1,312 @@
+import SwiftSyntaxMacros
+import SwiftSyntaxMacrosTestSupport
+import XCTest
+
+#if canImport(AutoMockMacros)
+import AutoMockMacros
+
+let testMacros: [String: Macro.Type] = [
+    "AutoMock": AutoMockMacro.self
+]
+#endif
+
+final class AutoMockTests: XCTestCase {
+    func testBasicComponentModelProtocol() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol HomeComponentModelProtocol: ComponentModel {
+                var isReady: Bool { get }
+                func onAppear() async
+            }
+            """,
+            expandedSource:
+            """
+            protocol HomeComponentModelProtocol: ComponentModel {
+                var isReady: Bool { get }
+                func onAppear() async
+            }
+
+            #if DEBUG
+            @Observable
+            final class HomeComponentModelMock: HomeComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                var isReady: Bool = false
+
+                func onAppear() async {
+                }
+            }
+            #endif
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testAllDefaultableTypes() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol SettingsComponentModelProtocol: ComponentModel {
+                var title: String { get }
+                var count: Int { get }
+                var enabled: Bool { get }
+                var subtitle: String? { get }
+                var ids: [Int] { get }
+                var attributes: [String: String] { get }
+            }
+            """,
+            expandedSource:
+            """
+            protocol SettingsComponentModelProtocol: ComponentModel {
+                var title: String { get }
+                var count: Int { get }
+                var enabled: Bool { get }
+                var subtitle: String? { get }
+                var ids: [Int] { get }
+                var attributes: [String: String] { get }
+            }
+
+            #if DEBUG
+            @Observable
+            final class SettingsComponentModelMock: SettingsComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                var title: String = ""
+                var count: Int = 0
+                var enabled: Bool = false
+                var subtitle: String? = nil
+                var ids: [Int] = []
+                var attributes: [String: String] = [:]
+            }
+            #endif
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testNonDefaultableType() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol DetailComponentModelProtocol: ComponentModel {
+                var projection: SomeProjection { get }
+                var isReady: Bool { get }
+            }
+            """,
+            expandedSource:
+            """
+            protocol DetailComponentModelProtocol: ComponentModel {
+                var projection: SomeProjection { get }
+                var isReady: Bool { get }
+            }
+
+            #if DEBUG
+            @Observable
+            final class DetailComponentModelMock: DetailComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                var projection: SomeProjection
+                var isReady: Bool = false
+
+                init(
+                    projection: SomeProjection
+                ) {
+                    self.projection = projection
+                }
+            }
+            #endif
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testReturningMethods() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol QueryComponentModelProtocol: ComponentModel {
+                func isItemSelected() -> Bool
+                func makeTitle() -> String
+                func makeProjection() -> SomeProjection
+            }
+            """,
+            expandedSource:
+            #"""
+            protocol QueryComponentModelProtocol: ComponentModel {
+                func isItemSelected() -> Bool
+                func makeTitle() -> String
+                func makeProjection() -> SomeProjection
+            }
+
+            #if DEBUG
+            @Observable
+            final class QueryComponentModelMock: QueryComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                func isItemSelected() -> Bool {
+                    false
+                }
+
+                func makeTitle() -> String {
+                    ""
+                }
+
+                func makeProjection() -> SomeProjection {
+                fatalError("\(#function) not stubbed in \(Self.self) — override the mock to use this method")
+                }
+            }
+            #endif
+            """#,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testTypedThrows() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol AuthComponentModelProtocol: ComponentModel {
+                func login() async throws(AppError)
+                func validate() async throws(AppError) -> Bool
+            }
+            """,
+            expandedSource:
+            """
+            protocol AuthComponentModelProtocol: ComponentModel {
+                func login() async throws(AppError)
+                func validate() async throws(AppError) -> Bool
+            }
+
+            #if DEBUG
+            @Observable
+            final class AuthComponentModelMock: AuthComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                func login() async throws(AppError) {
+                }
+
+                func validate() async throws(AppError) -> Bool {
+                    false
+                }
+            }
+            #endif
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testGetSetProperty() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol FormComponentModelProtocol: ComponentModel {
+                var firstName: String { get set }
+                var modalItem: SomeItem? { get set }
+            }
+            """,
+            expandedSource:
+            """
+            protocol FormComponentModelProtocol: ComponentModel {
+                var firstName: String { get set }
+                var modalItem: SomeItem? { get set }
+            }
+
+            #if DEBUG
+            @Observable
+            final class FormComponentModelMock: FormComponentModelProtocol {
+                var onEvent: (Event) -> Void = { _ in
+                }
+
+                var firstName: String = ""
+                var modalItem: SomeItem? = nil
+            }
+            #endif
+            """,
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testDiagnosticMustBeProtocol() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            struct NotAProtocol {
+            }
+            """,
+            expandedSource:
+            """
+            struct NotAProtocol {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "`@AutoMock` can only be applied to a `protocol`",
+                    line: 1,
+                    column: 1
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+
+    func testDiagnosticBadProtocolName() throws {
+        #if canImport(AutoMockMacros)
+        assertMacroExpansion(
+            """
+            @AutoMock
+            protocol Foo {
+            }
+            """,
+            expandedSource:
+            """
+            protocol Foo {
+            }
+            """,
+            diagnostics: [
+                DiagnosticSpec(
+                    message: "`@AutoMock` requires the protocol name to end in `Protocol` (e.g. `HomeComponentModelProtocol`) so the mock class name can be derived (`HomeComponentModelMock`)",
+                    line: 2,
+                    column: 10
+                )
+            ],
+            macros: testMacros
+        )
+        #else
+        throw XCTSkip("macros are only supported when running tests for the host platform")
+        #endif
+    }
+}


### PR DESCRIPTION
## Summary

- Adds `@AutoMock` macro that attaches to a `*ComponentModelProtocol` and emits a `#if DEBUG`-wrapped `@Observable final class <Name>Mock` as a peer declaration.
- Mock class includes `onEvent` stub, stored property for each protocol property (with primitive defaults), init for non-defaultable types, and empty/primitive-return stubs for every method.
- Customization via post-init mutation, convenience inits in `#if DEBUG` extension, or hand-rolled mock for protocols needing meaningful in-method behavior — no macro arguments needed in v1.

## Type-to-default mapping

| Type | Default | Init param? |
|---|---|---|
| `String` / `Bool` / numerics | `""` / `false` / `0` | No |
| `Optional<T>`, `T?` | `nil` | No |
| `Array<T>`, `[T]` | `[]` | No |
| `Dictionary<K, V>`, `[K: V]` | `[:]` | No |
| `Set<T>` | `[]` | No |
| Custom identifier types | no default | **Yes** |

## Diagnostics

- `mustBeProtocol` — applied to non-protocol decl
- `protocolNameMustEndInProtocol` — name lacks the `Protocol` suffix
- `unsupportedRequirement` — subscript / associatedtype / init in protocol

## Tests

8 cases via `assertMacroExpansion`: basic, all defaultable types, non-defaultable init, returning methods (incl. `fatalError` for custom returns), typed throws, `get set` properties, and both name diagnostics. Pre-existing `EnumIdentableTests` failures on `main` are unrelated.

## Out of scope

- `@CacheProjection` is shipping in #10.
- Adoption in `smsticket-ios` follows in `feature/auto-mock-adoption` once this is tagged `0.4.0`.